### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/Resources/config/services/fieldtype.yaml
+++ b/src/bundle/Resources/config/services/fieldtype.yaml
@@ -15,17 +15,17 @@ services:
         arguments:
             $fieldTypeIdentifier: '%ezplatform.fieldtype.matrix.identifier%'
         tags:
-            - { name: ezplatform.field_type, alias: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ibexa.field_type, alias: '%ezplatform.fieldtype.matrix.identifier%' }
 
     Ibexa\FieldTypeMatrix\FieldType\Converter\MatrixConverter:
         tags:
-            - { name: ezplatform.field_type.legacy_storage.converter, alias: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ibexa.field_type.storage.legacy.converter, alias: '%ezplatform.fieldtype.matrix.identifier%' }
 
     Ibexa\FieldTypeMatrix\FieldType\Mapper\MatrixFormMapper:
         tags:
-            - { name: ezplatform.field_type.form_mapper.definition, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
-            - { name: ezplatform.field_type.form_mapper.value, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ibexa.admin_ui.field_type.form.mapper.definition, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ibexa.admin_ui.field_type.form.mapper.value, fieldType: '%ezplatform.fieldtype.matrix.identifier%' }
 
     Ibexa\FieldTypeMatrix\FieldType\Indexable:
         tags:
-            - { name: ezplatform.field_type.indexable, alias: '%ezplatform.fieldtype.matrix.identifier%' }
+            - { name: ibexa.field_type.indexable, alias: '%ezplatform.fieldtype.matrix.identifier%' }

--- a/src/bundle/Resources/config/services/graphql.yaml
+++ b/src/bundle/Resources/config/services/graphql.yaml
@@ -13,15 +13,15 @@ services:
 
     Ibexa\FieldTypeMatrix\GraphQL\Schema\MatrixFieldDefinitionSchemaWorker:
         tags:
-            - { name: ezplatform_graphql.domain_schema_worker }
+            - { name: ibexa.graphql.domain.schema.worker }
 
     Ibexa\FieldTypeMatrix\GraphQL\Schema\MatrixFieldDefinitionInputSchemaWorker:
         tags:
-            - { name: ezplatform_graphql.domain_schema_worker }
+            - { name: ibexa.graphql.domain.schema.worker }
 
     Ibexa\FieldTypeMatrix\GraphQL\InputHandler:
         tags:
-            - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: ezmatrix }
+            - { name: ibexa.graphql.field_type.input.handler, fieldtype: ezmatrix }
 
     Ibexa\FieldTypeMatrix\GraphQL\FieldValueResolver:
         tags:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
