### PR TITLE
IBX-3059: Fixed resolveMatrixFieldValue argument

### DIFF
--- a/src/lib/GraphQL/FieldValueResolver.php
+++ b/src/lib/GraphQL/FieldValueResolver.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
 
 namespace Ibexa\FieldTypeMatrix\GraphQL;
 
-use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\GraphQL\Value\Item;
 use Ibexa\FieldTypeMatrix\FieldType\Value\RowsCollection;
 
 class FieldValueResolver
 {
-    public function resolveMatrixFieldValue(Content $content, string $fieldDefIdentifier): RowsCollection
+    public function resolveMatrixFieldValue(Item $item, string $fieldDefIdentifier): RowsCollection
     {
         $silentRows = [];
 
         /** @var \Ibexa\FieldTypeMatrix\FieldType\Value\RowsCollection $rows $rows */
-        $rows = $content->getFieldValue($fieldDefIdentifier)->getRows();
+        $rows = $item->getContent()->getFieldValue($fieldDefIdentifier)->getRows();
         foreach ($rows as $row) {
             $silentRows[] = new SilentRow($row->getCells());
         }

--- a/src/lib/GraphQL/FieldValueResolver.php
+++ b/src/lib/GraphQL/FieldValueResolver.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\FieldTypeMatrix\GraphQL;
 
-use Ibexa\GraphQL\Value\Item;
 use Ibexa\FieldTypeMatrix\FieldType\Value\RowsCollection;
+use Ibexa\GraphQL\Value\Item;
 
 class FieldValueResolver
 {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3059](https://issues.ibexa.co/browse/IBX-3059)
| **Type**                                   | bug
| **Target Ibexa version** | Ibexa Content `v4.1`
| **BC breaks**                          | no

`src/lib/GraphQL/FieldValueResolver->resolveMatrixFieldValu`e is using `Ibexa\Contracts\Core\Repository\Values\Content\Content`
Should be `Ibexa\GraphQL\Value\Item`

**Note:**
v3.3 works as it is now and should not be changed!
 
#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).