### PR TITLE
IBX-6559: Fixed `ezmatrix` field form inconsistencies in Content Type form

### DIFF
--- a/src/bundle/Resources/translations/matrix_fieldtype.en.xliff
+++ b/src/bundle/Resources/translations/matrix_fieldtype.en.xliff
@@ -31,11 +31,6 @@
         <target state="new">Columns</target>
         <note>key: field.columns</note>
       </trans-unit>
-      <trans-unit id="207b1ea4ef32f10b29a4cff6869126da1f4b980a" resname="field_definition.ezmatrix.columns">
-        <source>Columns</source>
-        <target state="new">Columns</target>
-        <note>key: field_definition.ezmatrix.columns</note>
-      </trans-unit>
       <trans-unit id="07c51cf854c53ebcc11d9261c7ca5b0772d7f7a4" resname="field_definition.ezmatrix.minimum_rows">
         <source>Minimum number of rows</source>
         <target state="new">Minimum number of rows</target>

--- a/src/bundle/Resources/views/themes/admin/matrix_fieldtype/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/matrix_fieldtype/field_types.html.twig
@@ -56,8 +56,7 @@
             body_rows,
             table_body_attr: {
                 'data-next-index': form.columns.children|length ? max(form.columns.children|keys) + 1 : 0,
-            },
-            show_head_cols_if_empty: true
+            }
         } %}
             {% block header %}
                 {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}

--- a/src/bundle/Resources/views/themes/admin/matrix_fieldtype/field_types.html.twig
+++ b/src/bundle/Resources/views/themes/admin/matrix_fieldtype/field_types.html.twig
@@ -56,7 +56,8 @@
             body_rows,
             table_body_attr: {
                 'data-next-index': form.columns.children|length ? max(form.columns.children|keys) + 1 : 0,
-            }
+            },
+            show_head_cols_if_empty: true
         } %}
             {% block header %}
                 {% embed '@ibexadesign/ui/component/table/table_header.html.twig' %}

--- a/src/lib/FieldType/Mapper/MatrixFormMapper.php
+++ b/src/lib/FieldType/Mapper/MatrixFormMapper.php
@@ -51,7 +51,7 @@ class MatrixFormMapper implements FieldDefinitionFormMapperInterface, FieldValue
                 'prototype_name' => '__number__',
                 'required' => false,
                 'property_path' => 'fieldSettings[columns]',
-                'label' => /** @Desc("Columns") */ 'field_definition.ezmatrix.columns',
+                'label' => false,
                 'translation_domain' => 'matrix_fieldtype',
                 'disabled' => $isTranslation,
             ]);


### PR DESCRIPTION
| Question                                  | Answer
| ----------------------------------------- | ------------------
| **JIRA issue**                            | [IBX-6559](https://issues.ibexa.co/browse/IBX-6559)
| **Type**                                  | bug
| **Target Ibexa DXP version**              | `v4.5` 
| **BC breaks**                             | no 

The label showing double "Columns" text is unnecessary so it was removed. Aside from that header columns are set to always visible.

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). 
- [x] Asked for a review (ping `@ibexa/engineering`).
