### PR TITLE
IBX-8006: Fixed matrix field resolving based on content's origin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzPlatformMatrixFieldtypeBundle\\": "src/bundle/",
-            "EzSystems\\EzPlatformMatrixFieldtype\\": "src/lib/",
             "Ibexa\\FieldTypeMatrix\\": "src/lib/",
-            "Ibexa\\Bundle\\FieldTypeMatrix\\": "src/bundle/"
+            "Ibexa\\Bundle\\FieldTypeMatrix\\": "src/bundle/",
+            "EzSystems\\EzPlatformMatrixFieldtypeBundle\\": "src/bundle/",
+            "EzSystems\\EzPlatformMatrixFieldtype\\": "src/lib/"
         }
     },
     "autoload-dev": {
@@ -57,5 +57,8 @@
         "branch-alias": {
             "dev-main": "4.5.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": false
     }
 }

--- a/src/bundle/Resources/config/services/graphql.yaml
+++ b/src/bundle/Resources/config/services/graphql.yaml
@@ -25,5 +25,11 @@ services:
             - { name: ibexa.graphql.field_type.input.handler, fieldtype: ezmatrix }
 
     Ibexa\FieldTypeMatrix\GraphQL\FieldValueResolver:
+        arguments:
+            $strategies: !tagged_iterator ibexa.graphql.field_type.matrix_resolver.content.strategy
         tags:
-            - {name: overblog_graphql.resolver, alias: "MatrixFieldValue", method: "resolveMatrixFieldValue"}
+            - { name: overblog_graphql.resolver, alias: "MatrixFieldValue", method: "resolveMatrixFieldValue" }
+
+    Ibexa\FieldTypeMatrix\GraphQL\Strategy\ItemContentResolvingStrategy:
+        tags:
+            - { name: ibexa.graphql.field_type.matrix_resolver.content.strategy, priority: -20 }

--- a/src/lib/GraphQL/FieldValueResolver.php
+++ b/src/lib/GraphQL/FieldValueResolver.php
@@ -24,6 +24,10 @@ class FieldValueResolver
         $this->strategies = $strategies;
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     */
     public function resolveMatrixFieldValue(object $item, string $fieldDefIdentifier): RowsCollection
     {
         $silentRows = [];

--- a/src/lib/GraphQL/FieldValueResolver.php
+++ b/src/lib/GraphQL/FieldValueResolver.php
@@ -8,17 +8,44 @@ declare(strict_types=1);
 
 namespace Ibexa\FieldTypeMatrix\GraphQL;
 
+use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\FieldTypeMatrix\FieldType\Value\RowsCollection;
-use Ibexa\GraphQL\Value\Item;
 
 class FieldValueResolver
 {
-    public function resolveMatrixFieldValue(Item $item, string $fieldDefIdentifier): RowsCollection
+    /** @var iterable<\Ibexa\FieldTypeMatrix\GraphQL\Strategy\ContentResolvingStrategyInterface> */
+    private iterable $strategies;
+
+    /**
+     * @param iterable<\Ibexa\FieldTypeMatrix\GraphQL\Strategy\ContentResolvingStrategyInterface> $strategies
+     */
+    public function __construct(iterable $strategies)
+    {
+        $this->strategies = $strategies;
+    }
+
+    public function resolveMatrixFieldValue(object $item, string $fieldDefIdentifier): RowsCollection
     {
         $silentRows = [];
+        $content = null;
+
+        foreach ($this->strategies as $strategy) {
+            if (!$strategy->supports($item)) {
+                continue;
+            }
+
+            $content = $strategy->resolveContent($item);
+        }
+
+        if ($content === null) {
+            throw new BadStateException(
+                '$item',
+                'GraphQL item cannot be resolved to a content.'
+            );
+        }
 
         /** @var \Ibexa\FieldTypeMatrix\FieldType\Value\RowsCollection $rows $rows */
-        $rows = $item->getContent()->getFieldValue($fieldDefIdentifier)->getRows();
+        $rows = $content->getFieldValue($fieldDefIdentifier)->getRows();
         foreach ($rows as $row) {
             $silentRows[] = new SilentRow($row->getCells());
         }

--- a/src/lib/GraphQL/Strategy/ContentResolvingStrategyInterface.php
+++ b/src/lib/GraphQL/Strategy/ContentResolvingStrategyInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\FieldTypeMatrix\GraphQL\Strategy;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+
+interface ContentResolvingStrategyInterface
+{
+    public function resolveContent(object $item): Content;
+
+    public function supports(object $item): bool;
+}

--- a/src/lib/GraphQL/Strategy/ItemContentResolvingStrategy.php
+++ b/src/lib/GraphQL/Strategy/ItemContentResolvingStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\FieldTypeMatrix\GraphQL\Strategy;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\GraphQL\Value\Item;
+
+final class ItemContentResolvingStrategy implements ContentResolvingStrategyInterface
+{
+    public function resolveContent(object $item): Content
+    {
+        /** @var \Ibexa\GraphQL\Value\Item $item */
+        return $item->getContent();
+    }
+
+    public function supports(object $item): bool
+    {
+        return $item instanceof Item;
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-8006

Fixes regression introduced by https://github.com/ibexa/product-catalog/pull/1144. 

It orbits around resolving content based on CT containing `matrix` fieldtype. Registering two resolvers with `MatrixFieldValue` alias resulted in overriding the first loaded one (`Ibexa\FieldTypeMatrix\GraphQL\FieldValueResolver`) with the second (`Ibexa\ProductCatalog\GraphQL\Resolver\MatrixFieldType\FieldValueResolver`) which in turn blowed up when content based on CT with `matrix` was created. 

The idea is to loosen up the type coming to the original resolver and introduce strategies allowing us to properly fetch content both from `Ibexa\GraphQL\Value\Item` and `Ibexa\Contracts\ProductCatalog\Values\ContentAwareProductInterface` (tackled within the companion PR https://github.com/ibexa/product-catalog/pull/1154).