### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.0'
+          - '8.3'
     steps:
       - uses: actions/checkout@v4
 
@@ -26,9 +26,9 @@ jobs:
           extensions: 'pdo_sqlite, gd'
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
+          dependency-versions: highest
 
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
@@ -42,7 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
           - '8.3'
 
     steps:
@@ -56,9 +55,9 @@ jobs:
           extensions: pdo_sqlite, gd
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
+          dependency-versions: highest
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -76,7 +75,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.2'
           - '8.3'
 
     steps:
@@ -90,9 +88,9 @@ jobs:
           extensions: pdo_sqlite, gd
           tools: cs2pr
 
-      - uses: "ramsey/composer-install@v2"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
+          dependency-versions: highest
 
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -14,8 +14,8 @@ jobs:
         timeout-minutes: 5
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '18'
             - run: yarn install

--- a/composer.json
+++ b/composer.json
@@ -21,35 +21,35 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ext-libxml": "*",
         "ext-simplexml": "*",
-        "ibexa/core": "~5.0.0@dev",
-        "ibexa/content-forms": "~5.0.0@dev",
-        "ibexa/graphql": "~5.0.0@dev",
-        "symfony/http-kernel": "^5.0",
-        "symfony/console": "^5.0",
+        "ibexa/content-forms": "~5.0.x-dev",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/graphql": "~5.0.x-dev",
         "symfony/config": "^5.0",
+        "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
-        "symfony/yaml": "^5.0",
         "symfony/form": "^5.0",
-        "symfony/options-resolver": "^5.0"
+        "symfony/http-kernel": "^5.0",
+        "symfony/options-resolver": "^5.0",
+        "symfony/yaml": "^5.0"
     },
     "require-dev": {
-        "ibexa/ci-scripts": "^0.2@dev",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "ibexa/admin-ui": "~5.0.0@dev",
-        "ibexa/user": "~5.0.0@dev",
-        "ibexa/fieldtype-richtext": "~5.0.0@dev",
-        "ibexa/search": "~5.0.0@dev",
-        "ibexa/rest": "~5.0.0@dev",
-        "ibexa/test-core": "~5.0.x-dev",
-        "ibexa/http-cache": "~5.0.0@dev",
-        "ibexa/design-engine": "~5.0.0@dev",
-        "ibexa/code-style": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpunit/phpunit": "^9.5",
-        "ibexa/notifications": "~5.0.x-dev"
+        "ibexa/admin-ui": "~5.0.x-dev",
+        "ibexa/ci-scripts": "^0.2@dev",
+        "ibexa/code-style": "^1.0",
+        "ibexa/design-engine": "~5.0.x-dev",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/fieldtype-richtext": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
+        "ibexa/search": "~5.0.x-dev",
+        "ibexa/test-core": "~5.0.x-dev",
+        "ibexa/user": "~5.0.x-dev",
+        "phpunit/phpunit": "^9.5"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
@@ -63,6 +63,7 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
