### PR TITLE
[Behat] IBX-8636: Added new tag to admin-ui job

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
             project-edition: 'oss'
             test-setup-phase-1: '--profile=setup --suite=content-translation --mode=standard'
-            test-suite: '--profile=browser --suite=admin-ui'
+            test-suite: '--profile=browser --suite=admin-ui --tags=~@IbexaDXP'
             timeout: 40
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
| :ticket: Issue | IBX-8636 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR adds new tag to admin ui job to exclude user profile test. In ibexa/behat repo we run admin-ui job on oss edition, Editor CT is enabled from headless edition, what causes a fail e.g. https://github.com/ibexa/fieldtype-matrix/actions/runs/10318602257/job/28565289162

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
