### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,15 @@
         "ibexa/fieldtype-richtext": "~5.0.x-dev",
         "ibexa/http-cache": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-symfony": "^2.0"
+        "phpstan/phpstan": "^1.12",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "phpstan/phpstan-symfony": "^1.4"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,199 +1,146 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Cannot access offset ''entries'' on array\|bool\|float\|int\|string\|null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
+			message: "#^Cannot access offset 'entries' on array\\|bool\\|float\\|int\\|string\\|null\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Cannot call method fetchAll\(\) on Doctrine\\DBAL\\ForwardCompatibility\\Result\|int\|string\.$#'
-			identifier: method.nonObject
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 2
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Cannot call method fetchColumn\(\) on Doctrine\\DBAL\\ForwardCompatibility\\Result\|int\|string\.$#'
-			identifier: method.nonObject
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeMatrix\\Command\\MigrateLegacyMatrixCommand\:\:convertCellsToRows\(\) has parameter \$cells with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\Bundle\\\\FieldTypeMatrix\\\\Command\\\\MigrateLegacyMatrixCommand\\:\\:convertCellsToRows\\(\\) has parameter \\$cells with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeMatrix\\Command\\MigrateLegacyMatrixCommand\:\:convertCellsToRows\(\) has parameter \$columns with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\Bundle\\\\FieldTypeMatrix\\\\Command\\\\MigrateLegacyMatrixCommand\\:\\:convertCellsToRows\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeMatrix\\Command\\MigrateLegacyMatrixCommand\:\:convertCellsToRows\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\Bundle\\\\FieldTypeMatrix\\\\Command\\\\MigrateLegacyMatrixCommand\\:\\:convertCellsToRows\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeMatrix\\Command\\MigrateLegacyMatrixCommand\:\:getContentClassAttributes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\Bundle\\\\FieldTypeMatrix\\\\Command\\\\MigrateLegacyMatrixCommand\\:\\:getContentClassAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\FieldTypeMatrix\\Command\\MigrateLegacyMatrixCommand\:\:getContentObjectAttributes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\Bundle\\\\FieldTypeMatrix\\\\Command\\\\MigrateLegacyMatrixCommand\\:\\:getContentObjectAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Variable \$xml might not be defined\.$#'
-			identifier: variable.undefined
+			message: "#^Variable \\$xml might not be defined\\.$#"
 			count: 1
 			path: src/bundle/Command/MigrateLegacyMatrixCommand.php
 
 		-
-			message: '#^Parameter \#1 \$input of static method Symfony\\Component\\Yaml\\Yaml\:\:parse\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
+			message: "#^Parameter \\#1 \\$input of static method Symfony\\\\Component\\\\Yaml\\\\Yaml\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaFieldTypeMatrixExtension.php
 
 		-
-			message: '#^Property Ibexa\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition\:\:\$dataText5 \(string\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
+			message: "#^Property Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\StorageFieldDefinition\\:\\:\\$dataText5 \\(string\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: src/lib/FieldType/Converter/MatrixConverter.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:__construct\(\) has parameter \$cells with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:__construct\\(\\) has parameter \\$cells with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:__get\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:__get\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:__get\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:__get\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:__isset\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:__isset\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:getCells\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:getCells\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
-			identifier: argument.type
+			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(string\\)\\: bool\\)\\|null, 'strlen' given\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Property Ibexa\\FieldTypeMatrix\\FieldType\\Value\\Row\:\:\$cells type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Property Ibexa\\\\FieldTypeMatrix\\\\FieldType\\\\Value\\\\Row\\:\\:\\$cells type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/Value/Row.php
 
 		-
-			message: '#^Class Ibexa\\FieldTypeMatrix\\Form\\Type\\ColumnType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Type/ColumnType.php
-
-		-
-			message: '#^Class Ibexa\\FieldTypeMatrix\\Form\\Type\\FieldType\\MatrixCollectionType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Type/FieldType/MatrixCollectionType.php
-
-		-
-			message: '#^Class Ibexa\\FieldTypeMatrix\\Form\\Type\\FieldType\\MatrixEntryType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Type/FieldType/MatrixEntryType.php
-
-		-
-			message: '#^Class Ibexa\\FieldTypeMatrix\\Form\\Type\\FieldType\\MatrixFieldType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Type/FieldType/MatrixFieldType.php
-
-		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\InputHandler\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\InputHandler\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
 			count: 1
 			path: src/lib/GraphQL/InputHandler.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\InputHandler\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
-			identifier: missingType.parameter
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\InputHandler\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
 			count: 1
 			path: src/lib/GraphQL/InputHandler.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionInputSchemaWorker\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionInputSchemaWorker\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionInputSchemaWorker\:\:typeName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionInputSchemaWorker\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionInputSchemaWorker\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionInputSchemaWorker\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionSchemaWorker\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionSchemaWorker\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionSchemaWorker\:\:typeName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionSchemaWorker\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\Schema\\MatrixFieldDefinitionSchemaWorker\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\Schema\\\\MatrixFieldDefinitionSchemaWorker\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\SilentRow\:\:__get\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\SilentRow\\:\\:__get\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/GraphQL/SilentRow.php
 
 		-
-			message: '#^Method Ibexa\\FieldTypeMatrix\\GraphQL\\SilentRow\:\:__get\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
+			message: "#^Method Ibexa\\\\FieldTypeMatrix\\\\GraphQL\\\\SilentRow\\:\\:__get\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/lib/GraphQL/SilentRow.php
 
 		-
-			message: '#^Static property Ibexa\\Contracts\\Core\\Test\\Repository\\SetupFactory\\Legacy\:\:\$serviceContainer \(Ibexa\\Core\\Base\\ServiceContainer\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
+			message: "#^Static property Ibexa\\\\Contracts\\\\Core\\\\Test\\\\Repository\\\\SetupFactory\\\\Legacy\\:\\:\\$serviceContainer \\(Ibexa\\\\Core\\\\Base\\\\ServiceContainer\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: tests/lib/LegacySetupFactory.php

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,7 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+    ]);

--- a/src/bundle/Command/MigrateLegacyMatrixCommand.php
+++ b/src/bundle/Command/MigrateLegacyMatrixCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'ibexa:migrate:legacy_matrix')]
 class MigrateLegacyMatrixCommand extends Command
 {
     private const DEFAULT_ITERATION_COUNT = 1000;
@@ -49,7 +50,6 @@ class MigrateLegacyMatrixCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ibexa:migrate:legacy_matrix')
             ->addOption(
                 'iteration-count',
                 'c',


### PR DESCRIPTION
| :ticket: Issue | IBX-9584 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+. 

#### For QA:

Sanities.

#### Documentation:

N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
