### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,10 @@
         "ibexa/search": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
-        "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-phpunit": "^1.4",
-        "phpstan/phpstan-symfony": "^1.4"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
+        "phpunit/phpunit": "^9.5"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",

--- a/src/bundle/Command/MigrateLegacyMatrixCommand.php
+++ b/src/bundle/Command/MigrateLegacyMatrixCommand.php
@@ -16,6 +16,7 @@ use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 use Ibexa\FieldTypeMatrix\FieldType\Converter\MatrixConverter;
 use SimpleXMLElement;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,15 +24,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[\Symfony\Component\Console\Attribute\AsCommand(name: 'ibexa:migrate:legacy_matrix')]
+#[AsCommand(name: 'ibexa:migrate:legacy_matrix')]
 class MigrateLegacyMatrixCommand extends Command
 {
     private const DEFAULT_ITERATION_COUNT = 1000;
     private const EZMATRIX_IDENTIFIER = 'ezmatrix';
     private const CONFIRMATION_ANSWER = 'yes';
 
-    /** @var \Doctrine\DBAL\Connection */
-    private $connection;
+    private Connection $connection;
 
     /**
      * @param \Doctrine\DBAL\Connection $connection

--- a/src/lib/FieldType/Converter/MatrixConverter.php
+++ b/src/lib/FieldType/Converter/MatrixConverter.php
@@ -59,7 +59,7 @@ class MatrixConverter implements Converter
         $columns = array_values($fieldSettings['columns']);
         $minimumRows = (int)$fieldSettings['minimum_rows'];
 
-        array_walk($columns, static function ($column) {
+        array_walk($columns, static function ($column): array {
             return [
                 'identifier' => trim($column['identifier'] ?? ''),
                 'name' => trim($column['name'] ?? ''),

--- a/src/lib/FieldType/Type.php
+++ b/src/lib/FieldType/Type.php
@@ -31,8 +31,7 @@ class Type extends FieldType
         ],
     ];
 
-    /** @var string */
-    private $fieldTypeIdentifier;
+    private string $fieldTypeIdentifier;
 
     /**
      * @param string $fieldTypeIdentifier

--- a/src/lib/Form/Type/ColumnType.php
+++ b/src/lib/Form/Type/ColumnType.php
@@ -13,6 +13,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<array{name: string, identifier: string}>
+ */
 class ColumnType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/lib/Form/Type/FieldType/MatrixCollectionType.php
+++ b/src/lib/Form/Type/FieldType/MatrixCollectionType.php
@@ -14,6 +14,9 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<array<int, array<string, mixed>>>
+ */
 class MatrixCollectionType extends AbstractType
 {
     public function getName(): string

--- a/src/lib/Form/Type/FieldType/MatrixEntryType.php
+++ b/src/lib/Form/Type/FieldType/MatrixEntryType.php
@@ -15,6 +15,9 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<array<string, mixed>>
+ */
 class MatrixEntryType extends AbstractType
 {
     public function getName(): string

--- a/src/lib/Form/Type/FieldType/MatrixFieldType.php
+++ b/src/lib/Form/Type/FieldType/MatrixFieldType.php
@@ -68,7 +68,7 @@ class MatrixFieldType extends AbstractType
         $columnsByIdentifier = array_flip(array_column($options['columns'], 'identifier'));
 
         // Filter out unnecessary/obsolete columns data
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) use ($columnsByIdentifier) {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) use ($columnsByIdentifier): void {
             $value = $event->getData();
 
             /** @var \Ibexa\FieldTypeMatrix\FieldType\Value\Row $originalRow */

--- a/src/lib/Form/Type/FieldType/MatrixFieldType.php
+++ b/src/lib/Form/Type/FieldType/MatrixFieldType.php
@@ -19,27 +19,21 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @phpstan-extends \Symfony\Component\Form\AbstractType<array{entries: array<int, array<string, mixed>>}>
+ */
 class MatrixFieldType extends AbstractType
 {
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->getBlockPrefix();
     }
 
-    /**
-     * @return string
-     */
     public function getBlockPrefix(): string
     {
         return 'ezplatform_fieldtype_ezmatrix';
     }
 
-    /**
-     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefined(['columns', 'minimum_rows']);

--- a/src/lib/GraphQL/InputHandler.php
+++ b/src/lib/GraphQL/InputHandler.php
@@ -11,6 +11,7 @@ namespace Ibexa\FieldTypeMatrix\GraphQL;
 use Ibexa\Contracts\Core\FieldType\Value;
 use Ibexa\Contracts\GraphQL\Mutation\InputHandler\FieldTypeInputHandler;
 use Ibexa\FieldTypeMatrix\FieldType\Value as MatrixValue;
+use Ibexa\FieldTypeMatrix\FieldType\Value\Row;
 
 class InputHandler implements FieldTypeInputHandler
 {
@@ -18,8 +19,8 @@ class InputHandler implements FieldTypeInputHandler
     {
         return new MatrixValue(
             array_map(
-                static function (array $row) {
-                    return new MatrixValue\Row($row);
+                static function (array $row): Row {
+                    return new Row($row);
                 },
                 $input
             )

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionInputSchemaWorker.php
@@ -15,8 +15,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class MatrixFieldDefinitionInputSchemaWorker implements Worker
 {
-    /** @var \Ibexa\FieldTypeMatrix\GraphQL\Schema\NameHelper */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
     public function __construct(NameHelper $nameHelper)
     {

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionMapper.php
@@ -16,8 +16,7 @@ use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DecoratingFieldDe
 
 class MatrixFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
-    /** @var \Ibexa\FieldTypeMatrix\GraphQL\Schema\NameHelper */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
     /** @var iterable<\Ibexa\FieldTypeMatrix\FieldType\Mapper\FieldTypeToContentTypeStrategyInterface> */
     private iterable $strategies;

--- a/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
+++ b/src/lib/GraphQL/Schema/MatrixFieldDefinitionSchemaWorker.php
@@ -15,8 +15,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class MatrixFieldDefinitionSchemaWorker implements Worker
 {
-    /** @var \Ibexa\FieldTypeMatrix\GraphQL\Schema\NameHelper */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
     public function __construct(NameHelper $nameHelper)
     {


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

PHPStan bump is required due to requirements of Ibexa Rector and Rector itself.

#### For QA:

Regression tests.
