### PR TITLE
[Tests] Aligned integration tests to rely on core abstract with `Case` suffix

### DIFF
--- a/tests/lib/Repository/SearchServiceTest.php
+++ b/tests/lib/Repository/SearchServiceTest.php
@@ -13,9 +13,9 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\FieldTypeMatrix\FieldType\Value;
 use Ibexa\FieldTypeMatrix\FieldType\Value\Row;
-use Ibexa\Tests\Integration\Core\Repository\BaseTest;
+use Ibexa\Tests\Integration\Core\Repository\BaseTestCase;
 
-final class SearchServiceTest extends BaseTest
+final class SearchServiceTest extends BaseTestCase
 {
     public function testFindContentWithMatrixFieldType(): void
     {


### PR DESCRIPTION
> [!CAUTION]
> - [x] Remove TMP commit before merging

| :ticket: Issue | n/a |
|----------------|-----|

 
#### Related PRs: 
- https://github.com/ibexa/core/pull/567


#### Description:

Aligned `SearchServiceTest` integration test class with ibexa/core#567 changes adding `Case` suffix to abstract test case classes.

#### For QA:
No QA required.