### PR TITLE
Fixed test kernel bundle registration

### DIFF
--- a/tests/integration/Kernel.php
+++ b/tests/integration/Kernel.php
@@ -25,6 +25,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
 
 final class Kernel extends IbexaTestKernel
@@ -46,6 +47,7 @@ final class Kernel extends IbexaTestKernel
         yield new IbexaAdminUiBundle();
         yield new IbexaNotificationsBundle();
         yield new IbexaGraphQLBundle();
+        yield new TwigComponentBundle();
         yield new IbexaTwigComponentsBundle();
 
         yield new IbexaFieldTypeMatrixBundle();


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

#### Description:

Added the missing `TwigComponentBundle` to the integration test kernel so the test suite boots correctly on 5.0.